### PR TITLE
fix: nervina-labs/joyid is not a valid repo link

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -15,7 +15,7 @@ export default defineAppConfig({
     title: 'JoyID Docs',
     description: 'Developer documentation for JoyID',
     socials: {
-      github: 'nervina-labs/joyid',
+      github: 'nervina-labs/joyid-docs',
     },
     aside: {
       level: 1,

--- a/content/4.examples/3.ckb/1.ckb-demo.md
+++ b/content/4.examples/3.ckb/1.ckb-demo.md
@@ -1,4 +1,4 @@
 # Transfer CKB Demo
 
-- GitHub: <https://github.com/nervina-labs/joyid>
+- GitHub: <https://github.com/nervina-labs/joyid-docs>
 - Preview: <https://ckb-dapp-demo.joyid.dev/>


### PR DESCRIPTION
Replace it with https://github.com/nervina-labs/joyid-docs